### PR TITLE
fix: copy name when making a placeholder instance from a node

### DIFF
--- a/addons/godot_doctor/core/godot_doctor_validator.gd
+++ b/addons/godot_doctor/core/godot_doctor_validator.gd
@@ -173,6 +173,7 @@ func _make_instance_from_potential_placeholder_node(original_node: Node) -> Obje
 		return original_node
 
 	var new_instance: Node = script.new()
+	new_instance.name = original_node.name
 
 	for child in original_node.get_children():
 		new_instance.add_child(child.duplicate())


### PR DESCRIPTION
Fixed an issue where the placeholder instance had an empty name. This caused a bug in the 'children' example where 'Node.name' was used as the 'variable name'.