### PR TITLE
Feat/add array matches count by predicate

### DIFF
--- a/addons/godot_doctor/core/c_sharp/primitives/ValidationCondition.cs
+++ b/addons/godot_doctor/core/c_sharp/primitives/ValidationCondition.cs
@@ -378,6 +378,44 @@ public partial class ValidationCondition : GodotObject
 			(int)severity
 		);
 	}
+
+	/// <summary>
+	/// Creates a <see cref="ValidationCondition"/> that checks whether exactly <paramref name="expectedCount"/>
+	/// items are contained in the <paramref name="array"/> that match <paramref name="predicate"/>.
+	/// <paramref name="predicate"/> should take a single argument
+	/// (an item from the <paramref name="array"/>) and return a <see cref="bool"/> indicating whether
+	/// the item matches the condition.
+	/// This is useful for validating that an array contains a specific number of items matching
+	/// certain criteria.
+	/// An example predicate for an array that contains <see cref="Node"/> instances could be:
+	/// <c>value =&gt; value is Node node &amp;&amp; node.Name.ToString().BeginsWith(&quot;Enemy&quot;)</c>.
+	/// </summary>
+	/// <param name="array">The array to validate.</param>
+	/// <param name="expectedCount">The expected number of matching items.</param>
+	/// <param name="predicate">Predicate evaluated for each item in <paramref name="array"/>.</param>
+	/// <param name="predicateDescription">Optional human-readable description of <paramref name="predicate"/>.</param>
+	/// <param name="severity">
+	/// The severity level reported when validation fails.
+	/// Defaults to <see cref="Severity.Warning"/>.
+	/// </param>
+	/// <param name="variableName">The name of the variable that is being validated. Automatically inferred from the variable name in C#, but can be overridden.</param>
+	public static ValidationCondition ArrayMatchesCountByPredicate<[MustBeVariant] T>(
+		Godot.Collections.Array<T> array,
+		int expectedCount,
+		Func<T, bool> predicate,
+		string predicateDescription = "",
+		Severity severity = Severity.Warning,
+		[CallerArgumentExpression(nameof(array))] string variableName = "Array"
+	) =>
+		FromGdStatic(
+			"array_matches_count_by_predicate",
+			array,
+			expectedCount,
+			Callable.From(predicate),
+			variableName,
+			predicateDescription,
+			(int)severity
+		);
 }
 
 public static class ValidationConditionExtensions

--- a/addons/godot_doctor/core/primitives/validation_condition.gd
+++ b/addons/godot_doctor/core/primitives/validation_condition.gd
@@ -385,6 +385,45 @@ static func is_scene_of_type(
 	)
 
 
+## Creates a [ValidationCondition] that checks whether exactly [param expected_count]
+## items are contained in the [param array] that match [param predicate].
+## [param predicate] should be a [Callable] that takes a single argument
+## (an item from the [param array]) and returns a [code]bool[/code] indicating whether
+## the item matches the condition.
+## This is useful for validating that an array contains a specific number of items matching
+## certain criteria.
+## An example predicate for an [code]Array[/code] that contains [Node]s could be:
+## [code]func(value: Node): return value.name.begins_with("Enemy")[/code].
+static func array_matches_count_by_predicate(
+	array: Array,
+	expected_count: int,
+	predicate: Callable,
+	variable_name: String = "Array",
+	predicate_description: String = "",
+	severity_level: Severity = Severity.WARNING
+) -> ValidationCondition:
+	var get_actual_count: Callable = func() -> int:
+		return array.reduce(
+			func(acc: int, value: Variant) -> int:
+				return acc + 1 if value != null and predicate.call(value) else acc,
+			0
+		)
+
+	return ValidationCondition.new(
+		func() -> bool: return get_actual_count.call() == expected_count,
+		(
+			"%s has %d items matching the predicate, expected %d.%s"
+			% [
+				variable_name,
+				get_actual_count.call(),
+				expected_count,
+				(" (Predicate: %s)" % predicate_description) if predicate_description else "",
+			]
+		),
+		severity_level
+	)
+
+
 ## Extracts the class name from [param packed_scene]'s root node's script.
 ## Returns a [GodotDoctorClassNameQueryResult] indicating whether a script
 ## and class name were found.

--- a/addons/godot_doctor/examples/README.md
+++ b/addons/godot_doctor/examples/README.md
@@ -21,6 +21,13 @@ used, and how to reproduce/resolve the errors.
 **Core Concept:** **General Validation Use Cases** A collection of various
 validation scenarios in a 'real-world' context.
 
+### [verify_array_matches_count_by_predicate_example](./gdscript/verify_array_matches_count_by_predicate_example/README.md)
+
+**Core Concept:** **Array Count Validation with Predicates** Shows how to
+validate that an exported array property contains a specific number of elements
+that match a given condition (predicate), such as ensuring an array of nodes has
+at least 3 elements that are of a certain type or have specific properties.
+
 ### [verify_default_validations_example](./gdscript/verify_default_validations_example/README.md)
 
 **Core Concept:** **No-Code Default Validations** Demonstrates Godot Doctor's

--- a/addons/godot_doctor/examples/csharp/verify_array_matches_count_by_predicate_example/ExampleFactory.cs
+++ b/addons/godot_doctor/examples/csharp/verify_array_matches_count_by_predicate_example/ExampleFactory.cs
@@ -7,7 +7,7 @@ public partial class ExampleFactory : Node
 	[Export]
 	public ExampleProductBase.Type TypeToSpawn { get; set; }
 
-	public ExampleProductBase SpawnProduct(ExampleProductBase.Type type)
+	public static ExampleProductBase SpawnProduct(ExampleProductBase.Type type)
 	{
 		ExampleProductBase spawnedProduct = null;
 		switch (type)

--- a/addons/godot_doctor/examples/csharp/verify_array_matches_count_by_predicate_example/ExampleFactory.cs
+++ b/addons/godot_doctor/examples/csharp/verify_array_matches_count_by_predicate_example/ExampleFactory.cs
@@ -1,0 +1,11 @@
+using Godot;
+
+namespace GodotDoctor.Examples.VerifyArrayMatchesCountByPredicateExample;
+
+public partial class ExampleFactory : Node
+{
+	[Export]
+	public ExampleProductBase.Type TypeToSpawn { get; set; } = ExampleProductBase.Type.A;
+
+	public ExampleProductBase SpawnProduct() => null;
+}

--- a/addons/godot_doctor/examples/csharp/verify_array_matches_count_by_predicate_example/ExampleFactory.cs
+++ b/addons/godot_doctor/examples/csharp/verify_array_matches_count_by_predicate_example/ExampleFactory.cs
@@ -5,7 +5,24 @@ namespace GodotDoctor.Examples.VerifyArrayMatchesCountByPredicateExample;
 public partial class ExampleFactory : Node
 {
 	[Export]
-	public ExampleProductBase.Type TypeToSpawn { get; set; } = ExampleProductBase.Type.A;
+	public ExampleProductBase.Type TypeToSpawn { get; set; }
 
-	public ExampleProductBase SpawnProduct() => null;
+	public ExampleProductBase SpawnProduct(ExampleProductBase.Type type)
+	{
+		ExampleProductBase spawnedProduct = null;
+		switch (type)
+		{
+			case ExampleProductBase.Type.A:
+				spawnedProduct = new ExampleProductA();
+				break;
+			case ExampleProductBase.Type.B:
+				spawnedProduct = new ExampleProductB();
+				break;
+			default:
+				GD.PushError($"Unknown product type: {type}");
+				break;
+		}
+
+		return spawnedProduct;
+	}
 }

--- a/addons/godot_doctor/examples/csharp/verify_array_matches_count_by_predicate_example/ExampleFactory.cs.uid
+++ b/addons/godot_doctor/examples/csharp/verify_array_matches_count_by_predicate_example/ExampleFactory.cs.uid
@@ -1,0 +1,1 @@
+uid://d0l5f9r2u8m6n

--- a/addons/godot_doctor/examples/csharp/verify_array_matches_count_by_predicate_example/ExampleProductA.cs
+++ b/addons/godot_doctor/examples/csharp/verify_array_matches_count_by_predicate_example/ExampleProductA.cs
@@ -1,0 +1,5 @@
+using Godot;
+
+namespace GodotDoctor.Examples.VerifyArrayMatchesCountByPredicateExample;
+
+public partial class ExampleProductA : ExampleProductBase { }

--- a/addons/godot_doctor/examples/csharp/verify_array_matches_count_by_predicate_example/ExampleProductA.cs
+++ b/addons/godot_doctor/examples/csharp/verify_array_matches_count_by_predicate_example/ExampleProductA.cs
@@ -2,4 +2,7 @@ using Godot;
 
 namespace GodotDoctor.Examples.VerifyArrayMatchesCountByPredicateExample;
 
-public partial class ExampleProductA : ExampleProductBase { }
+public partial class ExampleProductA : ExampleProductBase
+{
+	public ExampleProductA() => ProductType = Type.A;
+}

--- a/addons/godot_doctor/examples/csharp/verify_array_matches_count_by_predicate_example/ExampleProductA.cs.uid
+++ b/addons/godot_doctor/examples/csharp/verify_array_matches_count_by_predicate_example/ExampleProductA.cs.uid
@@ -1,0 +1,1 @@
+uid://1n8d7kqv3s1mb

--- a/addons/godot_doctor/examples/csharp/verify_array_matches_count_by_predicate_example/ExampleProductB.cs
+++ b/addons/godot_doctor/examples/csharp/verify_array_matches_count_by_predicate_example/ExampleProductB.cs
@@ -2,4 +2,7 @@ using Godot;
 
 namespace GodotDoctor.Examples.VerifyArrayMatchesCountByPredicateExample;
 
-public partial class ExampleProductB : ExampleProductBase { }
+public partial class ExampleProductB : ExampleProductBase
+{
+	public ExampleProductB() => ProductType = Type.B;
+}

--- a/addons/godot_doctor/examples/csharp/verify_array_matches_count_by_predicate_example/ExampleProductB.cs
+++ b/addons/godot_doctor/examples/csharp/verify_array_matches_count_by_predicate_example/ExampleProductB.cs
@@ -1,0 +1,5 @@
+using Godot;
+
+namespace GodotDoctor.Examples.VerifyArrayMatchesCountByPredicateExample;
+
+public partial class ExampleProductB : ExampleProductBase { }

--- a/addons/godot_doctor/examples/csharp/verify_array_matches_count_by_predicate_example/ExampleProductB.cs.uid
+++ b/addons/godot_doctor/examples/csharp/verify_array_matches_count_by_predicate_example/ExampleProductB.cs.uid
@@ -1,0 +1,1 @@
+uid://cp6a2k3xw9t4h

--- a/addons/godot_doctor/examples/csharp/verify_array_matches_count_by_predicate_example/ExampleProductBase.cs
+++ b/addons/godot_doctor/examples/csharp/verify_array_matches_count_by_predicate_example/ExampleProductBase.cs
@@ -1,0 +1,12 @@
+using Godot;
+
+namespace GodotDoctor.Examples.VerifyArrayMatchesCountByPredicateExample;
+
+public partial class ExampleProductBase : Node
+{
+	public enum Type
+	{
+		A = 0,
+		B = 1,
+	}
+}

--- a/addons/godot_doctor/examples/csharp/verify_array_matches_count_by_predicate_example/ExampleProductBase.cs
+++ b/addons/godot_doctor/examples/csharp/verify_array_matches_count_by_predicate_example/ExampleProductBase.cs
@@ -2,11 +2,14 @@ using Godot;
 
 namespace GodotDoctor.Examples.VerifyArrayMatchesCountByPredicateExample;
 
-public partial class ExampleProductBase : Node
+public partial class ExampleProductBase : RefCounted
 {
 	public enum Type
 	{
-		A = 0,
-		B = 1,
+		None = 0,
+		A = 1,
+		B = 2,
 	}
+
+	public Type ProductType { get; protected set; } = Type.None;
 }

--- a/addons/godot_doctor/examples/csharp/verify_array_matches_count_by_predicate_example/ExampleProductBase.cs.uid
+++ b/addons/godot_doctor/examples/csharp/verify_array_matches_count_by_predicate_example/ExampleProductBase.cs.uid
@@ -1,0 +1,1 @@
+uid://db0d7j4f7ea0r

--- a/addons/godot_doctor/examples/csharp/verify_array_matches_count_by_predicate_example/ExampleSpawnFromFactory.cs
+++ b/addons/godot_doctor/examples/csharp/verify_array_matches_count_by_predicate_example/ExampleSpawnFromFactory.cs
@@ -1,0 +1,41 @@
+using Godot;
+using Godot.Collections;
+using GodotDoctor.Core;
+using GodotDoctor.Core.Primitives;
+
+namespace GodotDoctor.Examples.VerifyArrayMatchesCountByPredicateExample;
+
+public partial class ExampleSpawnFromFactory : Node, IValidatable
+{
+	[Export]
+	public Array<ExampleFactory> Factories { get; set; } = [];
+
+	[Export]
+	public int NumProductsForTypeA { get; set; } = 2;
+
+	[Export]
+	public int NumProductsForTypeB { get; set; } = 1;
+
+	public Array GetValidationConditions()
+	{
+		ValidationCondition[] conditions =
+		[
+			ValidationCondition.ArrayMatchesCountByPredicate(
+				Factories,
+				NumProductsForTypeA,
+				factory => factory != null && factory.TypeToSpawn == ExampleProductBase.Type.A,
+				predicateDescription: "TypeToSpawn is Type A",
+				variableName: nameof(Factories)
+			),
+			ValidationCondition.ArrayMatchesCountByPredicate(
+				Factories,
+				NumProductsForTypeB,
+				factory => factory != null && factory.TypeToSpawn == ExampleProductBase.Type.B,
+				predicateDescription: "TypeToSpawn is Type B",
+				variableName: nameof(Factories)
+			),
+		];
+
+		return conditions.ToGodotArray();
+	}
+}

--- a/addons/godot_doctor/examples/csharp/verify_array_matches_count_by_predicate_example/ExampleSpawnFromFactory.cs.uid
+++ b/addons/godot_doctor/examples/csharp/verify_array_matches_count_by_predicate_example/ExampleSpawnFromFactory.cs.uid
@@ -1,0 +1,1 @@
+uid://b2w7z4p9v6k1c

--- a/addons/godot_doctor/examples/csharp/verify_array_matches_count_by_predicate_example/README.md
+++ b/addons/godot_doctor/examples/csharp/verify_array_matches_count_by_predicate_example/README.md
@@ -1,0 +1,6 @@
+# Example: Verifying Array Match Counts By Predicate (C#)
+
+This is the C# variant of the verify_array_matches_count_by_predicate example.
+
+It demonstrates using ValidationCondition.ArrayMatchesCountByPredicate to validate that
+an exported factory array contains the expected number of entries matching a predicate.

--- a/addons/godot_doctor/examples/csharp/verify_array_matches_count_by_predicate_example/README.md
+++ b/addons/godot_doctor/examples/csharp/verify_array_matches_count_by_predicate_example/README.md
@@ -1,6 +1,6 @@
 # Example: Verifying Array Match Counts By Predicate (C#)
 
-This is the C# variant of the verify_array_matches_count_by_predicate example.
+This is the C# variant of the Verify Array Matches Count By Predicate Example.
 
-It demonstrates using ValidationCondition.ArrayMatchesCountByPredicate to validate that
-an exported factory array contains the expected number of entries matching a predicate.
+For a full explanation of this example, see the
+[GDScript version](../../gdscript/verify_array_matches_count_by_predicate_example/README.md).

--- a/addons/godot_doctor/examples/csharp/verify_array_matches_count_by_predicate_example/verify_array_matches_count_by_predicate_example_cs.tscn
+++ b/addons/godot_doctor/examples/csharp/verify_array_matches_count_by_predicate_example/verify_array_matches_count_by_predicate_example_cs.tscn
@@ -11,6 +11,7 @@ Factories = [NodePath("Factories/ExampleFactoryForTypeA"), NodePath("Factories/E
 
 [node name="ExampleFactoryForTypeA" type="Node" parent="Factories" unique_id=1907466397]
 script = ExtResource("2_h3f9k")
+TypeToSpawn = 1
 
 [node name="ExampleFactoryForTypeA2" type="Node" parent="Factories" unique_id=109680805]
 script = ExtResource("2_h3f9k")

--- a/addons/godot_doctor/examples/csharp/verify_array_matches_count_by_predicate_example/verify_array_matches_count_by_predicate_example_cs.tscn
+++ b/addons/godot_doctor/examples/csharp/verify_array_matches_count_by_predicate_example/verify_array_matches_count_by_predicate_example_cs.tscn
@@ -1,0 +1,21 @@
+[gd_scene format=3 uid="uid://bx2nnhm4e6gju"]
+
+[ext_resource type="Script" uid="uid://b2w704qav6k1c" path="res://addons/godot_doctor/examples/csharp/verify_array_matches_count_by_predicate_example/ExampleSpawnFromFactory.cs" id="1_i5n4g"]
+[ext_resource type="Script" uid="uid://d0l5gar2u8m6n" path="res://addons/godot_doctor/examples/csharp/verify_array_matches_count_by_predicate_example/ExampleFactory.cs" id="2_h3f9k"]
+
+[node name="VerifyArrayMatchesCountByPredicateExampleCs" type="Node" unique_id=1035634273 node_paths=PackedStringArray("Factories")]
+script = ExtResource("1_i5n4g")
+Factories = [NodePath("Factories/ExampleFactoryForTypeA"), NodePath("Factories/ExampleFactoryForTypeA2"), NodePath("Factories/ExampleFactoryForTypeB")]
+
+[node name="Factories" type="Node" parent="." unique_id=1229861716]
+
+[node name="ExampleFactoryForTypeA" type="Node" parent="Factories" unique_id=1907466397]
+script = ExtResource("2_h3f9k")
+
+[node name="ExampleFactoryForTypeA2" type="Node" parent="Factories" unique_id=109680805]
+script = ExtResource("2_h3f9k")
+TypeToSpawn = 1
+
+[node name="ExampleFactoryForTypeB" type="Node" parent="Factories" unique_id=588807592]
+script = ExtResource("2_h3f9k")
+TypeToSpawn = 1

--- a/addons/godot_doctor/examples/gdscript/verify_array_matches_count_by_predicate_example/README.md
+++ b/addons/godot_doctor/examples/gdscript/verify_array_matches_count_by_predicate_example/README.md
@@ -1,0 +1,69 @@
+# Example: Verifying Array Match Counts By Predicate
+
+This example demonstrates Godot Doctor's ability to validate that an array
+contains the expected number of entries matching custom predicate conditions.
+
+## The Issue
+
+Sometimes, we need to enforce not just that items exist in an array, but that
+**the right number of items** satisfy specific criteria.
+
+In this example, we have an exported `factories` array where each factory has a
+`type_to_spawn` value (`A` or `B`). We want to assert that:
+
+1. Exactly 2 factories spawn type `A`
+2. Exactly 1 factory spawns type `B`
+
+Without explicit validation, this kind of distribution bug can go unnoticed
+until runtime logic depends on those counts.
+
+## The Solution
+
+Use `ValidationCondition.array_matches_count_by_predicate()` inside
+`_get_validation_conditions()`.
+
+This helper takes:
+
+1. The target array
+2. The expected match count
+3. A predicate callable that decides whether an item is a match
+4. Optional description fields for clearer error messages
+
+This allows you to express count-based validation rules declaratively and run
+them at design time.
+
+## This Example
+
+The scene `verify_array_matches_count_by_predicate_example.tscn` contains an
+`ExampleSpawnFromFactory` node with the script
+`example_spawn_from_factory.gd` attached.
+
+That script defines two validations:
+
+```gdscript
+ValidationCondition.array_matches_count_by_predicate(
+ factories,
+ num_products_for_type_a,
+ func(factory: ExampleFactory) -> bool:
+  return factory.type_to_spawn == ExampleProductBase.Type.A,
+ "factories",
+ "type_to_spawn is Type A"
+),
+ValidationCondition.array_matches_count_by_predicate(
+ factories,
+ num_products_for_type_b,
+ func(factory: ExampleFactory) -> bool:
+  return factory.type_to_spawn == ExampleProductBase.Type.B,
+ "factories",
+ "type_to_spawn is Type B"
+)
+```
+
+In the provided scene data:
+
+1. `num_products_for_type_a` is `2`
+2. `num_products_for_type_b` is `1`
+3. The actual factory setup yields `1` factory for type `A` and `2` for type `B`
+
+So both validations fail, demonstrating how predicate-based count checks produce
+clear, targeted errors.

--- a/addons/godot_doctor/examples/gdscript/verify_array_matches_count_by_predicate_example/README.md
+++ b/addons/godot_doctor/examples/gdscript/verify_array_matches_count_by_predicate_example/README.md
@@ -35,8 +35,8 @@ them at design time.
 ## This Example
 
 The scene `verify_array_matches_count_by_predicate_example.tscn` contains an
-`ExampleSpawnFromFactory` node with the script
-`example_spawn_from_factory.gd` attached.
+`ExampleSpawnFromFactory` node with the script `example_spawn_from_factory.gd`
+attached.
 
 That script defines two validations:
 

--- a/addons/godot_doctor/examples/gdscript/verify_array_matches_count_by_predicate_example/README.md
+++ b/addons/godot_doctor/examples/gdscript/verify_array_matches_count_by_predicate_example/README.md
@@ -63,7 +63,11 @@ In the provided scene data:
 
 1. `num_products_for_type_a` is `2`
 2. `num_products_for_type_b` is `1`
-3. The actual factory setup yields `1` factory for type `A` and `2` for type `B`
+3. The actual factory setup yields `3` factories for type `A`, and `0` for type
+   `B`, as the inspector value for the `type_to_spawn` for
+   `ExampleFactoryForTypeB` is incorrectly set to `B`.
 
 So both validations fail, demonstrating how predicate-based count checks produce
 clear, targeted errors.
+
+Setting the `type_to_spawn` for `ExampleFactoryForTypeB` to `B` fixes the issue.

--- a/addons/godot_doctor/examples/gdscript/verify_array_matches_count_by_predicate_example/example_factory.gd
+++ b/addons/godot_doctor/examples/gdscript/verify_array_matches_count_by_predicate_example/example_factory.gd
@@ -4,6 +4,13 @@ extends Node
 @export var type_to_spawn: ExampleProductBase.Type
 
 
-func spawn_product() -> ExampleProductBase:
-	# Stub implementation, in a real implementation this would instance a scene or something like that
-	return null
+func spawn_product(type: ExampleProductBase.Type) -> ExampleProductBase:
+	var spawned_product: ExampleProductBase = null
+	match type:
+		ExampleProductBase.Type.A:
+			spawned_product = ExampleProductA.new()
+		ExampleProductBase.Type.B:
+			spawned_product = ExampleProductB.new()
+		_:
+			push_error("Unknown product type: %s" % type)
+	return spawned_product

--- a/addons/godot_doctor/examples/gdscript/verify_array_matches_count_by_predicate_example/example_factory.gd
+++ b/addons/godot_doctor/examples/gdscript/verify_array_matches_count_by_predicate_example/example_factory.gd
@@ -1,0 +1,9 @@
+class_name ExampleFactory
+extends Node
+
+@export var type_to_spawn: ExampleProductBase.Type
+
+
+func spawn_product() -> ExampleProductBase:
+	# Stub implementation, in a real implementation this would instance a scene or something like that
+	return null

--- a/addons/godot_doctor/examples/gdscript/verify_array_matches_count_by_predicate_example/example_factory.gd.uid
+++ b/addons/godot_doctor/examples/gdscript/verify_array_matches_count_by_predicate_example/example_factory.gd.uid
@@ -1,0 +1,1 @@
+uid://cxknf2emdd34j

--- a/addons/godot_doctor/examples/gdscript/verify_array_matches_count_by_predicate_example/example_product_a.gd
+++ b/addons/godot_doctor/examples/gdscript/verify_array_matches_count_by_predicate_example/example_product_a.gd
@@ -1,0 +1,11 @@
+extends Node
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta: float) -> void:
+	pass

--- a/addons/godot_doctor/examples/gdscript/verify_array_matches_count_by_predicate_example/example_product_a.gd
+++ b/addons/godot_doctor/examples/gdscript/verify_array_matches_count_by_predicate_example/example_product_a.gd
@@ -3,7 +3,7 @@ extends Node
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
-	pass # Replace with function body.
+	pass  # Replace with function body.
 
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.

--- a/addons/godot_doctor/examples/gdscript/verify_array_matches_count_by_predicate_example/example_product_a.gd
+++ b/addons/godot_doctor/examples/gdscript/verify_array_matches_count_by_predicate_example/example_product_a.gd
@@ -1,11 +1,6 @@
-extends Node
+class_name ExampleProductA
+extends ExampleProductBase
 
 
-# Called when the node enters the scene tree for the first time.
-func _ready() -> void:
-	pass  # Replace with function body.
-
-
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta: float) -> void:
-	pass
+func _init():
+	type = Type.A

--- a/addons/godot_doctor/examples/gdscript/verify_array_matches_count_by_predicate_example/example_product_a.gd.uid
+++ b/addons/godot_doctor/examples/gdscript/verify_array_matches_count_by_predicate_example/example_product_a.gd.uid
@@ -1,0 +1,1 @@
+uid://kmsy4lronoej

--- a/addons/godot_doctor/examples/gdscript/verify_array_matches_count_by_predicate_example/example_product_b.gd
+++ b/addons/godot_doctor/examples/gdscript/verify_array_matches_count_by_predicate_example/example_product_b.gd
@@ -1,0 +1,11 @@
+extends Node
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta: float) -> void:
+	pass

--- a/addons/godot_doctor/examples/gdscript/verify_array_matches_count_by_predicate_example/example_product_b.gd
+++ b/addons/godot_doctor/examples/gdscript/verify_array_matches_count_by_predicate_example/example_product_b.gd
@@ -3,7 +3,7 @@ extends Node
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
-	pass # Replace with function body.
+	pass  # Replace with function body.
 
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.

--- a/addons/godot_doctor/examples/gdscript/verify_array_matches_count_by_predicate_example/example_product_b.gd
+++ b/addons/godot_doctor/examples/gdscript/verify_array_matches_count_by_predicate_example/example_product_b.gd
@@ -1,11 +1,6 @@
-extends Node
+class_name ExampleProductB
+extends ExampleProductBase
 
 
-# Called when the node enters the scene tree for the first time.
-func _ready() -> void:
-	pass  # Replace with function body.
-
-
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta: float) -> void:
-	pass
+func _init() -> void:
+	type = Type.B

--- a/addons/godot_doctor/examples/gdscript/verify_array_matches_count_by_predicate_example/example_product_b.gd.uid
+++ b/addons/godot_doctor/examples/gdscript/verify_array_matches_count_by_predicate_example/example_product_b.gd.uid
@@ -1,0 +1,1 @@
+uid://cujxpx5fj5lto

--- a/addons/godot_doctor/examples/gdscript/verify_array_matches_count_by_predicate_example/example_product_base.gd
+++ b/addons/godot_doctor/examples/gdscript/verify_array_matches_count_by_predicate_example/example_product_base.gd
@@ -1,0 +1,4 @@
+@abstract class_name ExampleProductBase
+extends Node
+
+enum Type { A, B }

--- a/addons/godot_doctor/examples/gdscript/verify_array_matches_count_by_predicate_example/example_product_base.gd
+++ b/addons/godot_doctor/examples/gdscript/verify_array_matches_count_by_predicate_example/example_product_base.gd
@@ -1,4 +1,6 @@
 @abstract class_name ExampleProductBase
-extends Node
+extends RefCounted
 
-enum Type { A, B }
+enum Type { NONE, A, B }
+
+var type: Type = Type.NONE

--- a/addons/godot_doctor/examples/gdscript/verify_array_matches_count_by_predicate_example/example_product_base.gd.uid
+++ b/addons/godot_doctor/examples/gdscript/verify_array_matches_count_by_predicate_example/example_product_base.gd.uid
@@ -1,0 +1,1 @@
+uid://bmf0ubfjgihbs

--- a/addons/godot_doctor/examples/gdscript/verify_array_matches_count_by_predicate_example/example_spawn_from_factory.gd
+++ b/addons/godot_doctor/examples/gdscript/verify_array_matches_count_by_predicate_example/example_spawn_from_factory.gd
@@ -1,0 +1,35 @@
+class_name ExampleSpawnFromFactory
+extends Node
+
+@export var factories: Array[ExampleFactory] = []
+
+@export var num_products_for_type_a: int = 2
+@export var num_products_for_type_b: int = 1
+
+
+func _get_validation_conditions() -> Array[ValidationCondition]:
+	return [
+		# This condition checks that the factories array contains the
+		# expected amount of factories that spawn products of type A and B
+		# respectively, demonstrating how to use
+		# ValidationCondition.array_matches_count_by_predicate to validate
+		# the contents of an array based on a custom predicate function.
+		# In this case, the predicate function checks the type_to_spawn property
+		# of each factory to determine whether that factory spawns a product of the expected type.
+		ValidationCondition.array_matches_count_by_predicate(
+			factories,
+			num_products_for_type_a,
+			func(factory: ExampleFactory) -> bool:
+				return factory.type_to_spawn == ExampleProductBase.Type.A,
+			"factories",
+			"type_to_spawn is Type A"
+		),
+		ValidationCondition.array_matches_count_by_predicate(
+			factories,
+			num_products_for_type_b,
+			func(factory: ExampleFactory) -> bool:
+				return factory.type_to_spawn == ExampleProductBase.Type.B,
+			"factories",
+			"type_to_spawn is Type B"
+		),
+	]

--- a/addons/godot_doctor/examples/gdscript/verify_array_matches_count_by_predicate_example/example_spawn_from_factory.gd.uid
+++ b/addons/godot_doctor/examples/gdscript/verify_array_matches_count_by_predicate_example/example_spawn_from_factory.gd.uid
@@ -1,0 +1,1 @@
+uid://b7aujsl7wknw2

--- a/addons/godot_doctor/examples/gdscript/verify_array_matches_count_by_predicate_example/verify_array_matches_count_by_predicate_example.tscn
+++ b/addons/godot_doctor/examples/gdscript/verify_array_matches_count_by_predicate_example/verify_array_matches_count_by_predicate_example.tscn
@@ -1,0 +1,24 @@
+[gd_scene format=3 uid="uid://bptwqcubq2ypw"]
+
+[ext_resource type="Script" uid="uid://b7aujsl7wknw2" path="res://addons/godot_doctor/examples/gdscript/verify_array_matches_count_by_predicate_example/example_spawn_from_factory.gd" id="1_gjcie"]
+[ext_resource type="Script" uid="uid://cxknf2emdd34j" path="res://addons/godot_doctor/examples/gdscript/verify_array_matches_count_by_predicate_example/example_factory.gd" id="2_l3xsl"]
+
+[node name="ExampleSpawnFromFactory" type="Node" unique_id=1224695581 node_paths=PackedStringArray("factories")]
+script = ExtResource("1_gjcie")
+factories = [NodePath("Factories/ExampleFactoryForTypeA"), NodePath("Factories/ExampleFactoryForTypeA2"), NodePath("Factories/ExampleFactoryForTypeB")]
+
+[node name="Factories" type="Node" parent="." unique_id=1618796967]
+
+[node name="ExampleFactoryForTypeA" type="Node" parent="Factories" unique_id=688322283]
+script = ExtResource("2_l3xsl")
+metadata/_custom_type_script = "uid://cxknf2emdd34j"
+
+[node name="ExampleFactoryForTypeA2" type="Node" parent="Factories" unique_id=375753390]
+script = ExtResource("2_l3xsl")
+type_to_spawn = 1
+metadata/_custom_type_script = "uid://cxknf2emdd34j"
+
+[node name="ExampleFactoryForTypeB" type="Node" parent="Factories" unique_id=266512101]
+script = ExtResource("2_l3xsl")
+type_to_spawn = 1
+metadata/_custom_type_script = "uid://cxknf2emdd34j"

--- a/addons/godot_doctor/examples/gdscript/verify_array_matches_count_by_predicate_example/verify_array_matches_count_by_predicate_example.tscn
+++ b/addons/godot_doctor/examples/gdscript/verify_array_matches_count_by_predicate_example/verify_array_matches_count_by_predicate_example.tscn
@@ -11,6 +11,7 @@ factories = [NodePath("Factories/ExampleFactoryForTypeA"), NodePath("Factories/E
 
 [node name="ExampleFactoryForTypeA" type="Node" parent="Factories" unique_id=688322283]
 script = ExtResource("2_l3xsl")
+type_to_spawn = 1
 metadata/_custom_type_script = "uid://cxknf2emdd34j"
 
 [node name="ExampleFactoryForTypeA2" type="Node" parent="Factories" unique_id=375753390]

--- a/godot_doctor.csproj
+++ b/godot_doctor.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Godot.NET.Sdk/4.6.1">
+<Project Sdk="Godot.NET.Sdk/4.6.2">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <TargetFramework Condition=" '$(GodotTargetPlatform)' == 'android' ">net9.0</TargetFramework>


### PR DESCRIPTION
Adds `ValidationCondition.array_matches_count_by_predicate`.

This validates whether an array contains an exact number of values that match a predicate function.

This is a convenience method that eliminates the need to manually write ValidationConditions that use `array.reduce`and then `reduced_array.size()` to count the number of values that match a given predicate.

The C# wrapper variant includes another nicety which allows you to define the predicate using native `Func` rather than having to manually wrap it in a `Callable`.