### PR TITLE
fix: address `set_deferred` warning hint when copying size from controls

### DIFF
--- a/addons/godot_doctor/core/godot_doctor_validator.gd
+++ b/addons/godot_doctor/core/godot_doctor_validator.gd
@@ -242,7 +242,11 @@ func _copy_properties(from_node: Node, to_node: Node, extra_to_free: Array[Node]
 			var prop_name: StringName = prop.name
 			var value: Variant = from_node.get(prop_name)
 			var converted_value: Variant = _convert_placeholder_references(value, extra_to_free)
-			to_node.set(prop_name, converted_value)
+
+			if from_node is Control and prop_name == "size":
+				to_node.set_deferred(prop_name, converted_value)
+			else:
+				to_node.set(prop_name, converted_value)
 
 
 ## Recursively converts placeholder node references to proper instances.


### PR DESCRIPTION
For now, we just set_deferred if the `prop_name` is `size` and the node is a `Control`.

This hopefully doesn't cause too many issues later down the line, as this is quite a niche property, often determined by containers.
Note that this may introduce some odd-ball behavior as the size won't be properly set just yet until the next frame, so if you're doing some extremely niche validations on the size property this _may_ unexpectedly provide false positives.

We can revert this once we have some way of ignoring this warning (see: https://github.com/godotengine/godot/issues/113205 )

Closes #52 


