### PR TITLE
feat: validate on open

### DIFF
--- a/addons/godot_doctor/README.md
+++ b/addons/godot_doctor/README.md
@@ -177,9 +177,9 @@ enum InheritanceSearchStrategy {
 
 ### Automatic Scene Validation
 
-Validations run automatically when you save scenes, providing immediate feedback
-during development. Errors are displayed in a dedicated dock, and you can click
-on them to navigate directly to the problematic nodes.
+Validations run automatically when you open and save scenes, providing immediate
+feedback during development. Errors are displayed in a dedicated dock, and you
+can click on them to navigate directly to the problematic nodes.
 
 ![Godot Doctor Example Gif](/github_assets/gif/doctor_example.gif)
 

--- a/addons/godot_doctor/core/godot_doctor_runner.gd
+++ b/addons/godot_doctor/core/godot_doctor_runner.gd
@@ -40,6 +40,9 @@ signal run_complete
 ## The validator responsible for running validations and collecting results for this runner.
 var _validator: GodotDoctorValidator
 
+## Whether a validation run is queued for this frame.
+var _run_queued: bool = false
+
 
 ## Initializes the runner with [param validator].
 ## Exits with failure if [param validator] is [code]null[/code].
@@ -51,9 +54,20 @@ func _init(validator: GodotDoctorValidator) -> void:
 	_validator = validator
 
 
+## Queues a validation run for the end of the current frame.
+## Does nothing if a run is already queued.
+func queue_run() -> void:
+	if _run_queued:
+		return
+
+	_run_queued = true
+	run.call_deferred()
+
+
 ## Kicks off the validation run for this runner.
 func run() -> void:
 	_run()
+	_run_queued = false
 	run_complete.emit()
 
 

--- a/addons/godot_doctor/editor/godot_doctor_editor_runner.gd
+++ b/addons/godot_doctor/editor/godot_doctor_editor_runner.gd
@@ -33,6 +33,12 @@ func _run_for_edited_scene_root() -> void:
 		)
 		return
 
+	if current_edited_scene_root.scene_file_path.is_empty():
+		GodotDoctorNotifier.print_debug(
+			"Currently edited scene has not been saved to a file. Skipping scene validation.", self
+		)
+		return
+
 	started_run_for_edited_scene_root.emit(current_edited_scene_root)
 
 	started_scene_collection.emit()

--- a/addons/godot_doctor/godot_doctor_plugin.gd
+++ b/addons/godot_doctor/godot_doctor_plugin.gd
@@ -238,6 +238,9 @@ func _disconnect_all_tracked_signals() -> void:
 func _connect_signals():
 	GodotDoctorNotifier.print_debug("Connecting signals...", self)
 	_connect_and_track(scene_saved, _on_scene_saved)
+	_connect_and_track(scene_changed, _on_scene_changed)
+	var inspector: EditorInspector = EditorInterface.get_inspector()
+	_connect_and_track(inspector.edited_object_changed, _on_edited_object_changed)
 	_connect_runner_signals()
 	_connect_validator_signals()
 
@@ -401,6 +404,24 @@ func _on_scene_saved(file_path: String) -> void:
 	GodotDoctorNotifier.print_debug("Scene saved: %s" % file_path, self)
 	if settings.validate_on_save:
 		_active_runner.run()
+
+
+## Called when the user switches to another scene.
+## Triggers validation if [member GodotDoctorSettings.validate_on_open] is enabled.
+func _on_scene_changed(node: Node) -> void:
+	GodotDoctorNotifier.print_debug("Scene changed: %s" % node, self)
+	if settings.validate_on_open:
+		# It's possible the edited object also changed, so we must queue to prevent running twice
+		_active_runner.queue_run()
+
+
+## Called when the edited object in the inspector is changed by the user.
+## Triggers validation if [member GodotDoctorSettings.validate_on_open] is enabled.
+func _on_edited_object_changed() -> void:
+	GodotDoctorNotifier.print_debug("Edited object changed", self)
+	if settings.validate_on_open:
+		# It's possible the scene also changed, so we must queue to prevent running twice
+		_active_runner.queue_run()
 
 
 ## Called when the runner signals that the entire validation run is complete.

--- a/addons/godot_doctor/settings/godot_doctor_settings.gd
+++ b/addons/godot_doctor/settings/godot_doctor_settings.gd
@@ -10,9 +10,17 @@ extends Resource
 ## Whether to automatically check for plugin updates on plugin startup.
 @export var check_for_updates_on_startup: bool = true
 
-## Whether to automatically run validations when saving a script.
-## If this is set to [code]false[/code], users will need to manually trigger validations.
+## Whether to automatically run validations when saving a scene or resource.
+## [br]
+## If this is set to [code]false[/code], users will need to manually trigger validations after
+## making changes.
 @export var validate_on_save: bool = true
+
+## Whether to automatically run validations when opening a scene or resource.
+## [br]
+## If this is set to [code]false[/code], users will need to manually trigger validations or rely
+## on [member validate_on_save].
+@export var validate_on_open: bool = true
 
 @export_group("Notification settings")
 ## Whether to show the welcome dialog when enabling the plugin.


### PR DESCRIPTION
Closes #55 

It's possible (and quite likely) for `_on_scene_changed` and `_on_edited_object_changed` to fire at the same time. This would result in running validations twice, so I've added the `queue_run` function to prevent that.
(Running the validation twice does not lead to any issues, it's just unnecessary.)

I've also found an edge case that's likely an existing bug: If you validate a scene that has not been saved to a file (easiest way is to create a new inherited scene from an example), you will get an error from `GodotDoctorEditorRunner.to_res_path` (due to the path being an empty string).
I just added a check that aborts validation if the scene has no resource path.
This does mean Godot Doctor will show green/0 issues for these scenes. As Godot aggressively pushes you to save scenes I don't think this is a huge deal, but I'm open to other approaches. (Probably best addressed in a separate PR though)