### PR TITLE
Allow the ToGodotArray Extension function to be called with any kind of Collection

### DIFF
--- a/addons/godot_doctor/core/c_sharp/primitives/ValidationCondition.cs
+++ b/addons/godot_doctor/core/c_sharp/primitives/ValidationCondition.cs
@@ -416,7 +416,7 @@ public static class ValidationConditionExtensions
 	/// to a Godot array of their underlying <see cref="GodotObject"/> representations.
 	/// This is used to return validation conditions from C# to GDScript in a format that GDScript can work with.
 	/// </summary>
-	public static Godot.Collections.Array ToGodotArray(this ValidationCondition[] conditions)
+	public static Godot.Collections.Array ToGodotArray(this IReadOnlyCollection<ValidationCondition> conditions)
 	{
 		var godotArray = new Godot.Collections.Array();
 		foreach (var condition in conditions)

--- a/addons/godot_doctor/core/c_sharp/primitives/ValidationCondition.cs
+++ b/addons/godot_doctor/core/c_sharp/primitives/ValidationCondition.cs
@@ -421,6 +421,7 @@ public static class ValidationConditionExtensions
 		this IEnumerable<ValidationCondition> conditions
 	)
 	{
+		ArgumentNullException.ThrowIfNull(conditions);
 		var godotArray = new Godot.Collections.Array();
 		foreach (var condition in conditions)
 		{

--- a/addons/godot_doctor/core/c_sharp/primitives/ValidationCondition.cs
+++ b/addons/godot_doctor/core/c_sharp/primitives/ValidationCondition.cs
@@ -416,7 +416,7 @@ public static class ValidationConditionExtensions
 	/// to a Godot array of their underlying <see cref="GodotObject"/> representations.
 	/// This is used to return validation conditions from C# to GDScript in a format that GDScript can work with.
 	/// </summary>
-	public static Godot.Collections.Array ToGodotArray(this IReadOnlyCollection<ValidationCondition> conditions)
+	public static Godot.Collections.Array ToGodotArray(this IEnumerable<ValidationCondition> conditions)
 	{
 		var godotArray = new Godot.Collections.Array();
 		foreach (var condition in conditions)

--- a/addons/godot_doctor/core/c_sharp/primitives/ValidationCondition.cs
+++ b/addons/godot_doctor/core/c_sharp/primitives/ValidationCondition.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using Godot;
@@ -416,7 +417,9 @@ public static class ValidationConditionExtensions
 	/// to a Godot array of their underlying <see cref="GodotObject"/> representations.
 	/// This is used to return validation conditions from C# to GDScript in a format that GDScript can work with.
 	/// </summary>
-	public static Godot.Collections.Array ToGodotArray(this IEnumerable<ValidationCondition> conditions)
+	public static Godot.Collections.Array ToGodotArray(
+		this IEnumerable<ValidationCondition> conditions
+	)
 	{
 		var godotArray = new Godot.Collections.Array();
 		foreach (var condition in conditions)


### PR DESCRIPTION
`ToGodotArray ` did not allow other collections that Array. 

For example, when you want to create a `List<ValidationCondition>` or you would like to manipulate the `ValidationCondition`s using Linq, you have to first call `.ToArray()` and then `.ToGodotArray()`