### PR TITLE
fix: do not validate resources that have not been saved to file

### DIFF
--- a/addons/godot_doctor/editor/godot_doctor_editor_runner.gd
+++ b/addons/godot_doctor/editor/godot_doctor_editor_runner.gd
@@ -80,6 +80,16 @@ func _run_for_edited_resource() -> void:
 		)
 		return
 
+	if edited_resource.resource_path.is_empty():
+		GodotDoctorNotifier.print_debug(
+			(
+				"Edited resource %s has not been saved to a file. Skipping resource validation."
+				% edited_resource
+			),
+			self
+		)
+		return
+
 	started_run_for_edited_resource.emit()
 
 	started_run_for_resource.emit(edited_resource)


### PR DESCRIPTION
Me again. :)

Follow-up to #55 where I missed this edge case.
Creating a new resource (with validations and `class_name`/`[GlobalClass]`) runs validation while the "Save file" dialog is still open, which causes errors due to the missing path.

(Let me know if you need a separate issue, but I figured it's fine without since there hasn't been a release yet)

(I think the formatting looks a bit funny but that's all gdformat)